### PR TITLE
Make signup dialog responsive and style fixes

### DIFF
--- a/angular-instagram-profile/src/app/pages/profile/profile-signup-dialog-component/profile-signup-dialog-component.css
+++ b/angular-instagram-profile/src/app/pages/profile/profile-signup-dialog-component/profile-signup-dialog-component.css
@@ -31,8 +31,50 @@
   background-color: transparent;
   border: none;
 }
-:host ::ng-deep .p-button-lg {
+:host ::ng-deep .p-button.w-full .p-button-lg {
+  width: 100% !important;
+}
+:host ::ng-deep .p-button:not(.w-full) .p-button-lg {
+  width: auto !important;
+}
+
+:host ::ng-deep .p-inputgroup,
+:host ::ng-deep .p-password,
+:host ::ng-deep .p-password .p-inputtext,
+:host ::ng-deep .p-password .p-password-input,
+:host ::ng-deep .p-inputmask,
+:host ::ng-deep .p-datepicker-input,
+:host ::ng-deep .p-autocomplete-input {
+  min-width: 0;
+}
+
+:host ::ng-deep .p-password {
   width: 100%;
+}
+:host ::ng-deep .p-component .p-inputotp {
+  justify-content: center;
+}
+:host ::ng-deep .p-password .p-inputtext,
+:host ::ng-deep .p-password .p-password-input {
+  width: 100% !important;
+}
+:host ::ng-deep .p-password .p-password-icon,
+:host ::ng-deep .p-password .p-password-reveal-icon {
+  position: absolute !important;
+  right: 0.75rem !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+}
+
+:host ::ng-deep .signup-dialog .p-dialog,
+:host ::ng-deep .signup-dialog .p-dialog .p-dialog-content {
+  max-width: 100% !important;
+  overflow-x: hidden !important;
+}
+
+:host ::ng-deep .signup-dialog .p-stepper,
+:host ::ng-deep .signup-dialog .p-stepper .p-steps {
+  width: 100% !important;
 }
 
 :host ::ng-deep .inputmask-credentials input {
@@ -79,4 +121,71 @@
   width: 100%;
   height: 100%;
   cursor: pointer !important;
+}
+
+:host ::ng-deep .signup-dialog .p-dialog-content {
+  padding: 0 !important;
+}
+
+:host ::ng-deep .signup-dialog .p-dialog {
+  max-width: 100% !important;
+  overflow-x: hidden;
+}
+
+:host ::ng-deep .signup-dialog .p-dialog-content {
+  overflow-x: hidden;
+}
+
+@media (min-width: 360px) {
+  :host ::ng-deep .button-row {
+    flex-direction: row !important;
+    flex-wrap: nowrap !important;
+    justify-content: center !important;
+    align-items: center !important;
+  }
+
+  :host ::ng-deep .button-row .p-button,
+  :host ::ng-deep .button-row .w-full {
+    width: auto !important;
+    min-width: 0 !important;
+  }
+}
+
+@media (max-width: 340px) {
+  :host {
+    font-size: 1.2rem;
+  }
+
+  .file-input-div {
+    width: 80px;
+    height: 80px;
+  }
+
+  .file-input-div i,
+  :host ::ng-deep .p-stepper .p-step {
+    font-size: 1.2rem !important;
+  }
+
+  :host ::ng-deep .p-inputgroup,
+  :host ::ng-deep .p-inputmask,
+  :host ::ng-deep .p-datepicker-input,
+  :host ::ng-deep .p-autocomplete-input,
+  :host ::ng-deep .p-password input,
+  :host ::ng-deep .p-textarea textarea {
+    font-size: 1.1rem !important;
+  }
+
+  .div-date-of-birth,
+  .flex.flex-col.sm\:flex-row {
+    gap: 0.5rem;
+  }
+
+  .div-date-of-birth {
+    flex-direction: column !important;
+    align-items: stretch;
+  }
+
+  .file-input-div {
+    border-width: 1.5px;
+  }
 }

--- a/angular-instagram-profile/src/app/pages/profile/profile-signup-dialog-component/profile-signup-dialog-component.html
+++ b/angular-instagram-profile/src/app/pages/profile/profile-signup-dialog-component/profile-signup-dialog-component.html
@@ -3,6 +3,7 @@
   [modal]="true"
   [(visible)]="userService.visibleSignupDialog"
   (onHide)="userService.previousRoute({ replaceUrl: true })"
+  styleClass="signup-dialog w-full max-w-[45rem] sm:max-w-[42rem] lg:max-w-[48rem]"
 >
   <p-stepper [value]="1">
     <p-step-list>
@@ -13,7 +14,11 @@
       <!--! Account Information  -->
       <p-step-panel [value]="1">
         <ng-template #content let-activateCallback="activateCallback">
-          <form [formGroup]="userService.userForm" class="h-auto overflow-visible" action="">
+          <form
+            [formGroup]="userService.userForm"
+            class="h-auto overflow-visible w-full max-w-[42rem] mx-auto space-y-4 px-2 sm:px-4 md:px-6"
+            action=""
+          >
             <div class="my-5 flex flex-col items-center justify-center">
               <div class="file-input-div relative flex justify-center items-center">
                 <input
@@ -29,11 +34,11 @@
               <p-inputgroup-addon><i class="pi pi-user"></i> </p-inputgroup-addon>
               <input
                 formControlName="username"
-                class=""
                 pInputText
                 type="text"
                 name="username"
                 placeholder="Username"
+                class="w-full"
               />
             </p-input-group>
 
@@ -43,8 +48,8 @@
                   (onClick)="userService.useEmail = true"
                   class="h-full"
                   [disabled]="userService.useEmail === true"
-                  ><svg
-                    class=""
+                >
+                  <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="16"
                     height="16"
@@ -63,7 +68,7 @@
                   type="text"
                   formControlName="email"
                   pInputText
-                  class="inputmask-credentials"
+                  class="inputmask-credentials w-full"
                   placeholder="Email Address"
                 />
               } @else {
@@ -81,14 +86,16 @@
                 <p-button
                   (onClick)="userService.useEmail = false"
                   icon="pi pi-phone"
-                  class="h-full!"
+                  class="h-full"
                   [disabled]="userService.useEmail !== true"
                 />
               </p-inputgroup-addon>
             </p-input-group>
 
-            <div class="div-date-of-birth flex justify-center items-center gap-4 my-2 p-2">
-              <p-input-group class="input-group-date-of-birth flex-1">
+            <div
+              class="div-date-of-birth flex flex-col sm:flex-row justify-center items-stretch gap-4 my-2 p-2"
+            >
+              <p-input-group class="input-group-date-of-birth flex-1 min-w-0">
                 <p-inputgroup-addon>
                   <i class="pi pi-calendar"></i>
                 </p-inputgroup-addon>
@@ -96,7 +103,7 @@
                   appendTo="body"
                   placeholder="Your Birth Date"
                   formControlName="dateOfBirth"
-                  class="date-picker-date-of-birth"
+                  class="date-picker-date-of-birth w-full"
                   [showButtonBar]="true"
                   size="large"
                   dateFormat="dd/mm/yy"
@@ -105,11 +112,11 @@
               </p-input-group>
               <p-selectbutton
                 [options]="userService.genderOptions"
-                class="selectbutton-gender"
+                class="selectbutton-gender w-full sm:w-auto"
                 formControlName="gender"
               />
             </div>
-            <div class="flex justify-center items-center p-2 gap-2 my-2">
+            <div class="flex flex-col sm:flex-row justify-center items-stretch gap-3 p-2 my-2">
               <p-password
                 formControlName="password"
                 [toggleMask]="true"
@@ -137,6 +144,7 @@
                   appendTo="body"
                   placeholder="Select your city"
                   (completeMethod)="userService.updateSuggestedCities($event)"
+                  class="w-full"
                 />
               </p-input-group>
               <div class="flex flex-col">
@@ -146,19 +154,27 @@
                   rows="4"
                   cols="30"
                   pTextarea
-                  class="text-white"
+                  class="text-white min-h-[6rem]"
                 ></textarea>
               </div>
             </div>
 
-            <div class="flex justify-center items-center gap-5 my-4">
+            <div
+              class="button-row flex flex-col justify-center items-center gap-3 my-4 w-full flex-wrap"
+            >
               <p-button
                 severity="secondary"
                 (onClick)="userService.visibleSignupDialog = false"
                 routerLink="../"
                 label="Cancel"
+                styleClass="w-full sm:w-auto"
               ></p-button>
-              <p-button severity="success" label="Next" (onClick)="activateCallback(2)"></p-button>
+              <p-button
+                severity="success"
+                label="Next"
+                (onClick)="activateCallback(2)"
+                styleClass="w-full sm:w-auto"
+              ></p-button>
             </div>
           </form>
         </ng-template>
@@ -168,20 +184,34 @@
       <!--! Verification  -->
       <p-step-panel [value]="2">
         <ng-template #content let-activateCallback="activateCallback">
-          <form [formGroup]="userService.userForm" class="space-y-4">
-            <div class="w-full h-full flex flex-col justify-center items-center gap-4">
-              <span>Enter the OTP we've just sent to you </span>
-              <div class="flex justify-center">
-                <p-inputotp size="large" [integerOnly]="true" [length]="4" formControlName="otp" />
+          <form [formGroup]="userService.userForm" class="w-full space-y-4 px-2 sm:px-4 md:px-6">
+            <div class="w-full h-full flex flex-col items-center justify-center items-center gap-4">
+              <span class="text-center">Enter the OTP we've just sent to you </span>
+              <div class="flex justify-center w-full">
+                <p-inputotp
+                  size="large"
+                  [integerOnly]="true"
+                  [length]="4"
+                  formControlName="otp"
+                  class="w-full max-w-xs"
+                />
               </div>
             </div>
-            <div class="flex justify-center items-center gap-5 my-4">
+            <div
+              class="button-row flex flex-col justify-center items-center gap-3 my-4 w-full flex-wrap"
+            >
               <p-button
                 label="Cancel"
                 (onClick)="userService.visibleSignupDialog = false"
                 severity="secondary"
+                styleClass="w-full sm:w-auto"
               />
-              <p-button label="Submit" (onClick)="submitForm()" severity="success" />
+              <p-button
+                label="Submit"
+                (onClick)="submitForm()"
+                severity="success"
+                styleClass="w-full sm:w-auto"
+              />
             </div>
           </form>
         </ng-template>


### PR DESCRIPTION
Update signup dialog HTML and CSS to improve responsiveness and layout. CSS: add rules to control p-button sizing, input/datepicker/password widths, position password icons, constrain dialog/stepper widths and overflow, center OTP, and add media queries for small screens. HTML: add styleClass to dialog, apply responsive utility classes (w-full, max-w-*, px-*, flex-col/sm:flex-row) to the form, inputs, date-of-birth group, buttons and OTP input; reorganize button rows and ensure buttons become full-width on small screens. These changes aim to make the signup flow usable on narrow viewports and to standardize component sizing.